### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ node {
 	download = true
 	version = "9.11.1"
 	npmVersion = "5.6.0"
+	distBaseUrl = 'https://direct.nodejs.org/dist/'
 }
 
 //declare a build task


### PR DESCRIPTION
Hi, I've been following the course and getting the following error which this change fixes:

:nodeSetup FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':nodeSetup'.
> Could not resolve all files for configuration ':detachedConfiguration1'.
   > Could not resolve org.nodejs:node:9.11.1.
     Required by:
         project :
      > Could not resolve org.nodejs:node:9.11.1.
         > Could not get resource 'https://nodejs.org/dist/v9.11.1/ivy.xml'.
            > Could not GET 'https://nodejs.org/dist/v9.11.1/ivy.xml'. Received status code 403 from server: Forbidden

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org/